### PR TITLE
request node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/arteck/ioBroker.fullybrowser#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "readmeFilename": "README.md",
   "dependencies": {


### PR DESCRIPTION
adapter-core is known to fail when installed with node 14 as npm 6 does not install peerDependencies. So this adapter requires node 16 or newer.